### PR TITLE
fixup! [IMP] web_chatter_position: improve form and chatter layout styles

### DIFF
--- a/web_chatter_position/static/src/js/web_chatter_position.esm.js
+++ b/web_chatter_position/static/src/js/web_chatter_position.esm.js
@@ -46,12 +46,14 @@ patch(FormCompiler.prototype, {
                 isChatterAside: `__comp__.uiService.size >= ${SIZES.XXL}`,
             });
             setAttributes(chatterContainerHookXml, {
-                class: "o-aside",
+                class: "o-mail-ChatterContainer o-mail-Form-chatter o-aside w-print-100",
             });
             // For "bottom", we keep the chatter in the form sheet
             // (the one used for the attachment viewer case)
             // If it's not there, we create it.
         } else if (odoo.web_chatter_position === "bottom") {
+            // Force full width form view if chatter is set to bottom manually
+            formSheetBgXml.classList.add("o_fullwidth");
             if (webClientViewAttachmentViewHookXml) {
                 const sheetBgChatterContainerHookXml = res.querySelector(
                     ".o-mail-Form-chatter.o-isInFormSheetBg"

--- a/web_chatter_position/static/src/scss/chatter_form_adjustments.scss
+++ b/web_chatter_position/static/src/scss/chatter_form_adjustments.scss
@@ -1,9 +1,0 @@
-.o_form_view_container {
-    .o_form_sheet_bg .o_form_sheet {
-        max-width: none !important;
-        width: auto !important;
-    }
-    .o-mail-Form-chatter {
-        max-width: none;
-    }
-}

--- a/web_chatter_position/static/src/scss/form_controller.scss
+++ b/web_chatter_position/static/src/scss/form_controller.scss
@@ -2,16 +2,11 @@
     Copyright 2024 Alitec Pte Ltd (https://www.alitec.sg).
     License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 */
-
-.o_form_view {
-    .o_form_sheet_bg {
-        max-width: none;
-    }
-    .o_form_sheet {
-        max-width: $o-form-view-sheet-max-width;
-        width: 100%;
-        @include media-breakpoint-up(md) {
-            margin: $o-sheet-vpadding * 0.2 auto;
-        }
+// Set sheet to full width when chatter is forced to bottom
+.o_form_view_container {
+    .o_form_sheet_bg.o_fullwidth,
+    .o_form_sheet_bg.o_fullwidth .o_form_sheet {
+        max-width: none !important;
+        width: auto !important;
     }
 }


### PR DESCRIPTION
* Fix missing classes when chatter is forced aside, leading to a much smaller width of the chatter.
* Fix undesirable scrolling of the sheet instead of scrolling of the overflowing elements of the sheet when chatter is aligned to the side.
* Remove ineffective reference to .o-mail-Form-chatter aimed to make chatter go full width as well, which is a matter of preference. The main purpose of including web_sheet_width's css is to make the *sheet* use the space on the sides, not so much the chatter.
* Put new form view css into existing css file, replacing existing sizing tweaks.